### PR TITLE
Add initial configuration workflow for Radarr settings

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,17 @@ h1 {
   text-align: center;
   margin-bottom: 20px;
 }
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.header h1 {
+  margin: 0;
+  text-align: left;
+}
 h2 {
   margin-top: 30px;
   font-size: 1.2em;
@@ -38,7 +49,8 @@ form {
   text-align: right;
 }
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   flex: 1;
   padding: 5px;
   font-size: 1em;
@@ -48,9 +60,14 @@ form {
   border-radius: 3px;
 }
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-group textarea:focus {
   outline: none;
   border-color: #777;
+}
+.form-group textarea {
+  resize: vertical;
+  min-height: 90px;
 }
 .form-check {
   margin: 10px 0;
@@ -75,6 +92,39 @@ button[type="submit"] {
 }
 button[type="submit"]:hover {
   background: #3b78d8;
+}
+.link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  background: #3a3a3a;
+  border: 1px solid #555;
+  border-radius: 3px;
+  color: #e0e0e0;
+  text-decoration: none;
+  font-size: 0.95em;
+  transition: background 0.2s ease;
+}
+.link-button:hover {
+  background: #4a4a4a;
+}
+.alerts {
+  margin-bottom: 20px;
+}
+.alert {
+  background: #3a2a2a;
+  border: 1px solid #aa5555;
+  color: #ffaaaa;
+  padding: 10px 12px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+.help-text {
+  font-size: 0.85em;
+  color: #b0b0b0;
+  margin-top: -10px;
+  margin-bottom: 15px;
 }
 
 /* Debug console styles */

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <div class="container">
-    <h1>Radarr YouTube Video Importer</h1>
+    <div class="header">
+      <h1>Radarr YouTube Video Importer</h1>
+      <a class="link-button" href="{{ url_for('setup') }}">Settings</a>
+    </div>
     <form id="movieForm" novalidate>
       <div class="form-group">
         <label for="yturl">YouTube URL</label>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Initial Setup - Radarr YouTube Video Importer</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Radarr YouTube Video Importer</h1>
+      {% if configured %}
+        <a class="link-button" href="{{ url_for('index') }}">Back to App</a>
+      {% endif %}
+    </div>
+
+    <form method="post" novalidate>
+      <h2>Initial Configuration</h2>
+      <p class="help-text">Provide the details below so the app can connect to Radarr and locate your movie library.</p>
+
+      {% if errors %}
+        <div class="alerts">
+          {% for error in errors %}
+            <div class="alert">{{ error }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      <div class="form-group">
+        <label for="radarr_url">Radarr URL</label>
+        <input
+          type="url"
+          id="radarr_url"
+          name="radarr_url"
+          placeholder="http://localhost:7878"
+          value="{{ config.get('radarr_url', '') }}"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="radarr_api_key">Radarr API Key</label>
+        <input
+          type="text"
+          id="radarr_api_key"
+          name="radarr_api_key"
+          placeholder="Paste your Radarr API key"
+          value="{{ config.get('radarr_api_key', '') }}"
+          required
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="file_paths">Movie Library Paths</label>
+        <textarea
+          id="file_paths"
+          name="file_paths"
+          placeholder="One accessible path per line"
+          required
+        >{{- config.get('file_paths', []) | join('\n') -}}</textarea>
+      </div>
+      <p class="help-text">List each directory that contains your Radarr-managed movies, one per line.</p>
+
+      <button type="submit">Save Configuration</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a first-run setup flow that saves the Radarr URL, API key, and accessible library paths
- gate Radarr-dependent endpoints on the saved configuration and resolve movie folders using the configured paths
- refresh the UI with a settings link, setup template, and supporting styles

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68fe85a6f1d08329b068572befc0e6fd