### PR TITLE
Add advanced metadata controls and activity feed layout

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,5 +1,9 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('movieForm');
+  if (!form) {
+    return;
+  }
+
   const ytInput = document.getElementById('yturl');
   const movieNameInput = document.getElementById('movieName');
   const movieOptions = document.getElementById('movieOptions');
@@ -11,40 +15,298 @@ document.addEventListener('DOMContentLoaded', function() {
   const extSelect = document.getElementById('extension');
   const extraCheckbox = document.getElementById('extra');
   const extraTypeSelect = document.getElementById('extraType');
-  const extraNameGroup = document.getElementById('extraNameGroup');
+  const extraFields = document.getElementById('extraFields');
   const extraNameInput = document.getElementById('extra_name');
   const consoleDiv = document.getElementById('console');
+  const downloadsList = document.getElementById('downloadsList');
+
+  let downloadEntries = [];
+  const progressTimers = new Map();
+  const STATUS_LABELS = {
+    queued: 'Queued',
+    processing: 'Processing',
+    complete: 'Completed',
+    failed: 'Failed'
+  };
+  const RESOLUTION_LABELS = {
+    best: 'Best Available',
+    '1080p': 'Up to 1080p',
+    '720p': 'Up to 720p',
+    '480p': 'Up to 480p'
+  };
+  const EXTRA_TYPE_LABELS = {
+    trailer: 'Trailer',
+    behindthescenes: 'Behind the Scenes',
+    deleted: 'Deleted Scene',
+    featurette: 'Featurette',
+    interview: 'Interview',
+    scene: 'Scene',
+    short: 'Short',
+    other: 'Other'
+  };
+  const MAX_DOWNLOAD_ENTRIES = 8;
 
   function appendConsoleLine(text, isError) {
+    if (!consoleDiv) {
+      return;
+    }
     const lineElem = document.createElement('div');
     if (isError) {
       lineElem.classList.add('error-line');
     }
     lineElem.textContent = text;
     consoleDiv.appendChild(lineElem);
+    consoleDiv.scrollTop = consoleDiv.scrollHeight;
   }
 
   function resetConsole(message) {
+    if (!consoleDiv) {
+      return;
+    }
     consoleDiv.innerHTML = '';
     if (message) {
       appendConsoleLine(message, false);
     }
   }
 
+  function normalizeExtraLabel(type) {
+    if (!type) {
+      return '';
+    }
+    return EXTRA_TYPE_LABELS[type] || type;
+  }
+
+  function formatTime(value) {
+    if (!value) {
+      return '';
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    try {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (err) {
+      return date.toLocaleTimeString();
+    }
+  }
+
+  function cleanErrorText(text) {
+    if (!text) {
+      return '';
+    }
+    return text.replace(/^ERROR:\s*/i, '').trim();
+  }
+
+  function buildDownloadItem(entry) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'download-item';
+    wrapper.dataset.status = entry.status;
+
+    const header = document.createElement('div');
+    header.className = 'item-header';
+
+    const title = document.createElement('div');
+    title.className = 'item-title';
+    title.textContent = entry.label;
+    header.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+
+    const statusPill = document.createElement('span');
+    statusPill.className = 'status-pill';
+    statusPill.dataset.status = entry.status;
+    statusPill.textContent = STATUS_LABELS[entry.status] || entry.status;
+    meta.appendChild(statusPill);
+
+    if (entry.subtitle) {
+      const subtitle = document.createElement('span');
+      subtitle.textContent = entry.subtitle;
+      meta.appendChild(subtitle);
+    }
+
+    header.appendChild(meta);
+    wrapper.appendChild(header);
+
+    const progressBar = document.createElement('div');
+    progressBar.className = 'progress-bar';
+    const progressFill = document.createElement('div');
+    progressFill.className = 'progress-fill';
+    const progressValue = Math.max(0, Math.min(100, entry.progress || 0));
+    progressFill.style.width = `${progressValue}%`;
+    progressBar.appendChild(progressFill);
+    wrapper.appendChild(progressBar);
+
+    if (entry.message && entry.status === 'failed') {
+      const message = document.createElement('div');
+      message.className = 'download-error';
+      message.textContent = entry.message;
+      wrapper.appendChild(message);
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'item-footer';
+    const footerLeft = document.createElement('span');
+    const metadataText = (entry.metadata || []).filter(Boolean).join(' • ');
+    footerLeft.textContent = metadataText || ' ';
+    footer.appendChild(footerLeft);
+    const footerRight = document.createElement('span');
+    const timestamp = entry.status === 'complete' || entry.status === 'failed'
+      ? formatTime(entry.updatedAt || entry.startedAt)
+      : formatTime(entry.startedAt);
+    footerRight.textContent = timestamp;
+    footer.appendChild(footerRight);
+    wrapper.appendChild(footer);
+
+    return wrapper;
+  }
+
+  function renderDownloads() {
+    if (!downloadsList) {
+      return;
+    }
+    downloadsList.innerHTML = '';
+    if (!downloadEntries.length) {
+      downloadsList.classList.add('empty');
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No downloads yet.';
+      downloadsList.appendChild(empty);
+      return;
+    }
+    downloadsList.classList.remove('empty');
+    downloadEntries.forEach(entry => {
+      downloadsList.appendChild(buildDownloadItem(entry));
+    });
+  }
+
+  function stopProgress(id) {
+    const timer = progressTimers.get(id);
+    if (timer) {
+      clearInterval(timer);
+      progressTimers.delete(id);
+    }
+  }
+
+  function upsertDownload(update) {
+    if (!downloadsList || !update || !update.id) {
+      return;
+    }
+    const index = downloadEntries.findIndex(item => item.id === update.id);
+    if (index >= 0) {
+      const existing = downloadEntries[index];
+      const nextEntry = {
+        ...existing,
+        ...update,
+        metadata: update.metadata || existing.metadata,
+        subtitle: update.subtitle !== undefined ? update.subtitle : existing.subtitle,
+        message: update.message !== undefined ? update.message : existing.message,
+        startedAt: existing.startedAt,
+        updatedAt: new Date()
+      };
+      downloadEntries[index] = nextEntry;
+    } else {
+      const entry = {
+        metadata: [],
+        subtitle: '',
+        message: '',
+        progress: 0,
+        ...update,
+        progress: update.progress !== undefined ? update.progress : 0,
+        startedAt: update.startedAt || new Date(),
+        updatedAt: new Date()
+      };
+      downloadEntries.unshift(entry);
+      if (downloadEntries.length > MAX_DOWNLOAD_ENTRIES) {
+        const removed = downloadEntries.splice(MAX_DOWNLOAD_ENTRIES);
+        removed.forEach(item => stopProgress(item.id));
+      }
+    }
+    renderDownloads();
+  }
+
+  function startProgress(id) {
+    if (!downloadsList || progressTimers.has(id)) {
+      return;
+    }
+    const timer = setInterval(() => {
+      const entry = downloadEntries.find(item => item.id === id);
+      if (!entry) {
+        clearInterval(timer);
+        progressTimers.delete(id);
+        return;
+      }
+      if (entry.status !== 'processing') {
+        clearInterval(timer);
+        progressTimers.delete(id);
+        return;
+      }
+      const nextProgress = Math.min(90, (entry.progress || 0) + (Math.random() * 10 + 5));
+      upsertDownload({ id, progress: nextProgress });
+    }, 1500);
+    progressTimers.set(id, timer);
+  }
+
+  function createDownloadEntry(payload) {
+    if (!downloadsList) {
+      return null;
+    }
+    const now = new Date();
+    const fallbackTitle = payload.title || titleInput.value.trim();
+    const movieLabel = payload.movieName || fallbackTitle || 'Selected Movie';
+    const extraDescriptor = payload.extra
+      ? (payload.extra_name || normalizeExtraLabel(payload.extraType))
+      : '';
+    const label = extraDescriptor ? `${movieLabel} – ${extraDescriptor}` : movieLabel;
+    const metadata = [
+      `Format: ${(payload.extension || 'mp4').toUpperCase()}`,
+      `Resolution: ${RESOLUTION_LABELS[payload.resolution] || payload.resolution || 'Best Available'}`
+    ];
+    if (payload.extra) {
+      metadata.unshift(`Stored as extra content`);
+    }
+    return {
+      id: `dl-${now.getTime()}-${Math.floor(Math.random() * 1000)}`,
+      label: label || 'Radarr Download',
+      status: 'processing',
+      progress: 18,
+      metadata,
+      subtitle: payload.extra ? `Extra • ${extraDescriptor || normalizeExtraLabel(payload.extraType)}` : '',
+      startedAt: now,
+      updatedAt: now,
+      message: ''
+    };
+  }
+
+  function completeDownload(entryId, status, message) {
+    if (!entryId) {
+      return;
+    }
+    stopProgress(entryId);
+    upsertDownload({
+      id: entryId,
+      status,
+      progress: 100,
+      message: status === 'failed' ? message : ''
+    });
+  }
+
   function updateExtraVisibility() {
     if (extraCheckbox.checked) {
-      extraNameGroup.style.display = 'flex';
+      extraFields.style.display = 'block';
       extraNameInput.required = true;
     } else {
-      extraNameGroup.style.display = 'none';
+      extraFields.style.display = 'none';
       extraNameInput.required = false;
       extraNameInput.value = '';
+      extraTypeSelect.value = 'trailer';
     }
   }
 
   extraCheckbox.addEventListener('change', updateExtraVisibility);
 
-  movieNameInput.addEventListener('input', function() {
+  movieNameInput.addEventListener('input', () => {
     const inputVal = movieNameInput.value;
     let matched = false;
     for (let i = 0; i < movieOptions.options.length; i += 1) {
@@ -66,8 +328,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  form.addEventListener('submit', function(e) {
-    e.preventDefault();
+  form.addEventListener('submit', event => {
+    event.preventDefault();
 
     const payload = {
       yturl: ytInput.value.trim(),
@@ -103,6 +365,13 @@ document.addEventListener('DOMContentLoaded', function() {
       return;
     }
 
+    const downloadEntry = createDownloadEntry(payload);
+    const entryId = downloadEntry ? downloadEntry.id : null;
+    if (downloadEntry) {
+      upsertDownload(downloadEntry);
+      startProgress(downloadEntry.id);
+    }
+
     fetch('/create', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -110,25 +379,40 @@ document.addEventListener('DOMContentLoaded', function() {
     })
       .then(response => response.json().then(data => ({ ok: response.ok, data })))
       .then(({ ok, data }) => {
-        consoleDiv.innerHTML = '';
-        if (data.logs && data.logs.length > 0) {
-          data.logs.forEach(line => {
-            const isError = line.startsWith('ERROR');
+        if (consoleDiv) {
+          consoleDiv.innerHTML = '';
+        }
+        const logs = Array.isArray(data.logs) ? data.logs : [];
+        if (logs.length > 0) {
+          logs.forEach(line => {
+            const isError = typeof line === 'string' && line.startsWith('ERROR');
             appendConsoleLine(line, isError);
           });
         } else {
           appendConsoleLine('No output.', false);
         }
-        if (!ok && (!data.logs || !data.logs.some(line => line.startsWith('ERROR')))) {
+        const errorLines = logs.filter(line => typeof line === 'string' && line.startsWith('ERROR'));
+        const hasError = !ok || errorLines.length > 0;
+        if (!ok && errorLines.length === 0) {
           appendConsoleLine('ERROR: Request failed.', true);
         }
-        consoleDiv.scrollTop = consoleDiv.scrollHeight;
+        if (entryId) {
+          const message = hasError ? cleanErrorText(errorLines[0] || 'Request failed.') : '';
+          completeDownload(entryId, hasError ? 'failed' : 'complete', message);
+        }
       })
       .catch(err => {
-        consoleDiv.innerHTML = '';
-        appendConsoleLine('ERROR: ' + err, true);
+        if (consoleDiv) {
+          consoleDiv.innerHTML = '';
+        }
+        const message = err && err.message ? err.message : String(err);
+        appendConsoleLine('ERROR: ' + message, true);
+        if (entryId) {
+          completeDownload(entryId, 'failed', message);
+        }
       });
   });
 
   updateExtraVisibility();
+  renderDownloads();
 });

--- a/static/style.css
+++ b/static/style.css
@@ -5,14 +5,20 @@ body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
+  min-height: 100vh;
 }
 .container {
   max-width: 600px;
   margin: 40px auto;
   padding: 20px;
 }
+.app-shell {
+  max-width: 1200px;
+  margin: 32px auto 48px;
+  padding: 0 24px 24px;
+  box-sizing: border-box;
+}
 h1 {
-  text-align: center;
   margin-bottom: 20px;
 }
 .header {
@@ -20,15 +26,41 @@ h1 {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 }
 .header h1 {
   margin: 0;
   text-align: left;
 }
 h2 {
-  margin-top: 30px;
+  margin-top: 0;
   font-size: 1.2em;
+}
+
+.page-layout {
+  display: flex;
+  gap: 28px;
+  align-items: flex-start;
+}
+
+.main-column {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.side-column {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 32px;
+}
+
+.side-column h2 {
+  margin-bottom: 8px;
 }
 
 /* Form styles */
@@ -37,6 +69,9 @@ form {
   padding: 20px;
   border: 1px solid #3a3a3a;
   border-radius: 5px;
+}
+.main-column form {
+  margin-bottom: 0;
 }
 .form-group {
   display: flex;
@@ -81,6 +116,76 @@ form {
   display: inline-block;
   cursor: pointer;
 }
+
+#extraFields {
+  margin: 10px 0 20px;
+}
+
+.advanced-options {
+  margin: 20px 0;
+  background: #232323;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+
+.advanced-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.advanced-group h3 {
+  margin: 0 0 8px;
+  font-size: 1em;
+  font-weight: 600;
+}
+
+.advanced-group .form-group {
+  margin-bottom: 12px;
+}
+
+.advanced-options summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin: -10px -12px 10px;
+  padding: 10px 12px;
+  background: #2f2f2f;
+  border-bottom: 1px solid #3a3a3a;
+  border-radius: 4px 4px 0 0;
+  list-style: none;
+}
+
+.advanced-options summary::-webkit-details-marker {
+  display: none;
+}
+
+.advanced-options summary::after {
+  content: '\25B8';
+  float: right;
+  transition: transform 0.2s ease;
+}
+
+.advanced-options[open] summary {
+  border-bottom-color: #3a3a3a;
+}
+
+.advanced-options[open] summary::after {
+  transform: rotate(90deg);
+}
+
+.advanced-options .form-group {
+  margin-bottom: 12px;
+}
+
+.advanced-options .form-group:last-of-type {
+  margin-bottom: 0;
+}
+
+.advanced-group .help-text {
+  margin: 0 0 12px;
+}
+
 button[type="submit"] {
   background: #4e8ef7;
   color: #fff;
@@ -127,6 +232,143 @@ button[type="submit"]:hover {
   margin-bottom: 15px;
 }
 
+.activity-panel {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  padding: 18px 20px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.downloads-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.downloads-list.empty {
+  color: #9c9c9c;
+  font-size: 0.95em;
+}
+
+.downloads-list .empty-state {
+  padding: 12px 0;
+}
+
+.download-item {
+  background: #232323;
+  border: 1px solid #343434;
+  border-radius: 6px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.download-item .item-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.download-item .item-title {
+  font-weight: 600;
+  font-size: 0.95em;
+}
+
+.download-item .item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85em;
+  color: #b8b8b8;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #3a3a3a;
+  color: #e0e0e0;
+}
+
+.status-pill::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill[data-status='queued'] {
+  background: #3a3a3a;
+  color: #d0d0d0;
+}
+
+.status-pill[data-status='processing'] {
+  background: rgba(78, 142, 247, 0.25);
+  color: #79a8ff;
+}
+
+.status-pill[data-status='complete'] {
+  background: rgba(76, 175, 80, 0.25);
+  color: #7ed27f;
+}
+
+.status-pill[data-status='failed'] {
+  background: rgba(244, 67, 54, 0.25);
+  color: #ff8a80;
+}
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  background: #383838;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #4e8ef7, #3b78d8);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.download-item[data-status='complete'] .progress-fill {
+  background: linear-gradient(90deg, #4caf50, #2e7d32);
+}
+
+.download-item[data-status='failed'] .progress-fill {
+  background: linear-gradient(90deg, #ff6f61, #d84315);
+}
+
+.download-item .item-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.8em;
+  color: #b0b0b0;
+}
+
+.download-item .download-error {
+  font-size: 0.8em;
+  color: #ff8a80;
+}
+
 /* Debug console styles */
 .debug-console {
   background: #111;
@@ -141,4 +383,44 @@ button[type="submit"]:hover {
 }
 .debug-console .error-line {
   color: #ff5555;
+}
+
+@media (max-width: 1200px) {
+  .page-layout {
+    gap: 22px;
+  }
+}
+
+@media (max-width: 980px) {
+  .page-layout {
+    flex-direction: column;
+  }
+
+  .side-column {
+    position: static;
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .form-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-group label {
+    width: 100%;
+    text-align: left;
+    margin-bottom: 6px;
+  }
+
+  .help-text {
+    margin-top: 0;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,110 +7,148 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>
-  <div class="container">
+  <div class="app-shell">
     <div class="header">
       <h1>Radarr YouTube Video Importer</h1>
       <a class="link-button" href="{{ url_for('setup') }}">Settings</a>
     </div>
-    <form id="movieForm" novalidate>
-      <div class="form-group">
-        <label for="yturl">YouTube URL</label>
-        <input
-          type="url"
-          id="yturl"
-          name="yturl"
-          placeholder="https://www.youtube.com/watch?v=..."
-          pattern="^(https?:\\/\\/)?(www\\.)?(youtube\\.com|youtu\\.be)\\/.*$"
-          required
-        />
+
+    <div class="page-layout">
+      <div class="main-column">
+        <form id="movieForm" novalidate>
+          <div class="form-group">
+            <label for="yturl">YouTube URL</label>
+            <input
+              type="url"
+              id="yturl"
+              name="yturl"
+              placeholder="https://www.youtube.com/watch?v=..."
+              pattern="^(https?:\\/\\/)?(www\\.)?(youtube\\.com|youtu\\.be)\\/.*$"
+              required
+            />
+          </div>
+
+          <div class="form-group">
+            <label for="movieName">Movie</label>
+            <input
+              list="movieOptions"
+              id="movieName"
+              name="movieName"
+              placeholder="Start typing movie title..."
+              autocomplete="off"
+              required
+            />
+            <datalist id="movieOptions">
+              {% for movie in movies %}
+                <option
+                  data-id="{{ movie['id'] }}"
+                  data-title="{{ movie['title'] }}"
+                  data-year="{{ movie.get('year', '') }}"
+                  data-tmdb="{{ movie.get('tmdbId', '') }}"
+                  value="{{ movie['title'] }}{% if movie.get('year') %} ({{ movie['year'] }}){% endif %}"
+                ></option>
+              {% endfor %}
+            </datalist>
+          </div>
+          <input type="hidden" id="movieId" name="movieId" />
+
+          <div class="form-check">
+            <input type="checkbox" id="extra" name="extra" />
+            <label for="extra">Store in subfolder (treat as extra)</label>
+          </div>
+
+          <div id="extraFields" style="display: none;">
+            <div class="form-group">
+              <label for="extraType">Extra Type</label>
+              <select id="extraType" name="extraType">
+                <option value="trailer" selected>Trailer</option>
+                <option value="behindthescenes">Behind the Scenes</option>
+                <option value="deleted">Deleted Scene</option>
+                <option value="featurette">Featurette</option>
+                <option value="interview">Interview</option>
+                <option value="scene">Scene</option>
+                <option value="short">Short</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label for="extra_name">Extra Name</label>
+              <input
+                type="text"
+                id="extra_name"
+                name="extra_name"
+                placeholder="e.g., Official Teaser"
+              />
+            </div>
+          </div>
+
+          <details class="advanced-options">
+            <summary>Advanced Options</summary>
+            <div class="advanced-content">
+              <div class="advanced-group">
+                <h3>Download Preferences</h3>
+                <div class="form-group">
+                  <label for="resolution">Resolution Preference</label>
+                  <select id="resolution" name="resolution">
+                    <option value="best" selected>Best Available</option>
+                    <option value="1080p">Up to 1080p</option>
+                    <option value="720p">Up to 720p</option>
+                    <option value="480p">Up to 480p</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="extension">File Extension</label>
+                  <select id="extension" name="extension">
+                    <option value="mp4" selected>MP4</option>
+                    <option value="mkv">MKV</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="advanced-group">
+                <h3>Movie Metadata Overrides</h3>
+                <p class="help-text">
+                  These values default to the selected Radarr movie. Override them here only if you
+                  need custom metadata for the download.
+                </p>
+                <div class="form-group">
+                  <label for="title">Movie Title</label>
+                  <input type="text" id="title" name="title" placeholder="Movie Title" />
+                </div>
+
+                <div class="form-group">
+                  <label for="year">Year</label>
+                  <input type="text" id="year" name="year" placeholder="e.g., 2010" />
+                </div>
+
+                <div class="form-group">
+                  <label for="tmdb">TMDb ID</label>
+                  <input type="text" id="tmdb" name="tmdb" placeholder="Optional TMDb ID" />
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <button type="submit">Download Video</button>
+        </form>
+
+        <section class="activity-panel" aria-live="polite">
+          <div class="panel-header">
+            <h2>Downloads &amp; Processes</h2>
+          </div>
+          <div id="downloadsList" class="downloads-list empty">
+            <div class="empty-state">No downloads yet.</div>
+          </div>
+        </section>
       </div>
 
-      <div class="form-group">
-        <label for="movieName">Movie</label>
-        <input
-          list="movieOptions"
-          id="movieName"
-          name="movieName"
-          placeholder="Start typing movie title..."
-          autocomplete="off"
-          required
-        />
-        <datalist id="movieOptions">
-          {% for movie in movies %}
-            <option
-              data-id="{{ movie['id'] }}"
-              data-title="{{ movie['title'] }}"
-              data-year="{{ movie.get('year', '') }}"
-              data-tmdb="{{ movie.get('tmdbId', '') }}"
-              value="{{ movie['title'] }}{% if movie.get('year') %} ({{ movie['year'] }}){% endif %}"
-            ></option>
-          {% endfor %}
-        </datalist>
-      </div>
-      <input type="hidden" id="movieId" name="movieId" />
-
-      <div class="form-group">
-        <label for="title">Movie Title</label>
-        <input type="text" id="title" name="title" placeholder="Movie Title" />
-      </div>
-
-      <div class="form-group">
-        <label for="year">Year</label>
-        <input type="text" id="year" name="year" placeholder="e.g., 2010" />
-      </div>
-
-      <div class="form-group">
-        <label for="tmdb">TMDb ID</label>
-        <input type="text" id="tmdb" name="tmdb" placeholder="Optional TMDb ID" />
-      </div>
-
-      <div class="form-group">
-        <label for="extraType">Extra Type</label>
-        <select id="extraType" name="extraType">
-          <option value="trailer" selected>Trailer</option>
-          <option value="behindthescenes">Behind the Scenes</option>
-          <option value="deleted">Deleted Scene</option>
-          <option value="featurette">Featurette</option>
-          <option value="interview">Interview</option>
-          <option value="scene">Scene</option>
-          <option value="short">Short</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-
-      <div class="form-group">
-        <label for="resolution">Resolution Preference</label>
-        <select id="resolution" name="resolution">
-          <option value="best" selected>Best Available</option>
-          <option value="1080p">Up to 1080p</option>
-          <option value="720p">Up to 720p</option>
-          <option value="480p">Up to 480p</option>
-        </select>
-      </div>
-
-      <div class="form-group">
-        <label for="extension">File Extension</label>
-        <select id="extension" name="extension">
-          <option value="mp4" selected>MP4</option>
-          <option value="mkv">MKV</option>
-        </select>
-      </div>
-
-      <div class="form-check">
-        <input type="checkbox" id="extra" name="extra" />
-        <label for="extra">Store in subfolder (treat as extra)</label>
-      </div>
-
-      <div class="form-group" id="extraNameGroup" style="display: none;">
-        <label for="extra_name">Extra Name</label>
-        <input type="text" id="extra_name" name="extra_name" placeholder="e.g., Official Teaser" />
-      </div>
-
-      <button type="submit">Download Video</button>
-    </form>
-
-    <h2>Debug Console</h2>
-    <div id="console" class="debug-console">Ready.</div>
+      <aside class="side-column">
+        <h2>Debug Console</h2>
+        <div id="console" class="debug-console">Ready.</div>
+      </aside>
+    </div>
   </div>
 
   <script src="{{ url_for('static', filename='script.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- restructure the index view into a two-column layout with the debug console on the right and a downloads/processes panel under the main form
- move movie metadata inputs into the Advanced Options drawer alongside download preferences
- enhance the front-end script with a progress-tracked downloads list and safer console handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff5f53c83883298f5997fd636d6fe7