### PR TITLE
Add configurable Radarr path overrides for local libraries

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -231,6 +231,14 @@ button[type="submit"]:hover {
   margin-top: -10px;
   margin-bottom: 15px;
 }
+.help-text code {
+  display: inline-block;
+  padding: 0 4px;
+  background: #333;
+  border-radius: 3px;
+  color: #f5f5f5;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
 
 .activity-panel {
   background: #2a2a2a;

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -62,6 +62,16 @@
       </div>
       <p class="help-text">List each directory that contains your Radarr-managed movies, one per line.</p>
 
+      <div class="form-group">
+        <label for="path_overrides">Path Overrides</label>
+        <textarea
+          id="path_overrides"
+          name="path_overrides"
+          placeholder="/mnt/Movies =&gt; /Volumes/Movies"
+        >{{- overrides_text -}}</textarea>
+      </div>
+      <p class="help-text">Use overrides to map Radarr's movie paths to local directories on this machine. Format each line as <code>radarr/path =&gt; /local/path</code>.</p>
+
       <button type="submit">Save Configuration</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add configuration support for path overrides that remap Radarr library roots to local folders
- expose the new overrides field on the setup page and style inline code hints
- resolve movie paths using the configured overrides before falling back to folder-name matching

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ff7da05a5083299158090e3078742b