### PR TITLE
Mount Chrome cookie storage into container

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,7 +490,13 @@ def process_download_job(job_id: str, payload: Dict) -> None:
             try:
                 log("Querying yt-dlp for video title.")
                 proc = subprocess.run(
-                    ["yt-dlp", "--get-title", yt_url],
+                    [
+                        "yt-dlp",
+                        "--cookies-from-browser",
+                        "chrome",
+                        "--get-title",
+                        yt_url,
+                    ],
                     capture_output=True,
                     text=True,
                     check=True,
@@ -534,6 +540,8 @@ def process_download_job(job_id: str, payload: Dict) -> None:
         format_selector = build_format_selector(resolution)
         command = [
             "yt-dlp",
+            "--cookies-from-browser",
+            "chrome",
             "--newline",
             "-f",
             format_selector,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,5 @@ services:
       - "5010:5000"
     volumes:
       - /Users/gil/Downloads/test:/Movies
+      - "${HOME}/Library/Application Support/Google/Chrome/Default:/root/.config/google-chrome/Default:ro"
 


### PR DESCRIPTION
## Summary
- mount the host's Chrome cookie storage into the container so yt-dlp can access browser cookies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff9375c4e8832987dc1f560300a21d