### PR TITLE
Remove browser cookie handling and auth mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,3 @@ See `Dockerfile` to run in your Docker environment. Mount your Radarr movie libr
 - No secrets stored in the codebase
 - Runs as non-root inside the container
 
----
-
-Built for local use. LAN-only recommended. No authentication layer included (yet).


### PR DESCRIPTION
## Summary
- remove Chrome cookie discovery and usage from yt-dlp invocations
- clean up README to drop the obsolete authentication notice

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ffaf40e23c8329aa9b8aacb37d35d0