### PR TITLE
Adjust debug console layout height

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -82,7 +82,7 @@ h2 {
 .page-layout {
   display: flex;
   gap: 28px;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 .main-column {
@@ -99,6 +99,7 @@ h2 {
   gap: 16px;
   position: sticky;
   top: 32px;
+  align-self: stretch;
 }
 
 .side-column h2 {
@@ -467,7 +468,8 @@ button[type="submit"]:hover {
   font-size: 0.95em;
   padding: 10px;
   border: 1px solid #333;
-  height: 200px;
+  flex: 1 1 200px;
+  min-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary
- stretch the main and side columns so the debug console aligns with the main content height
- let the debug console flex to fill the sidebar while keeping scrollable overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffcd493c348329858f2a0a79941dd8