### PR TITLE
Always download best quality by removing resolution controls

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     titleInput: document.getElementById('title'),
     yearInput: document.getElementById('year'),
     tmdbInput: document.getElementById('tmdb'),
-    resolutionSelect: document.getElementById('resolution'),
     extensionSelect: document.getElementById('extension'),
     extraCheckbox: document.getElementById('extra'),
     extraTypeSelect: document.getElementById('extraType'),
@@ -27,13 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
     processing: 'Processing',
     complete: 'Completed',
     failed: 'Failed'
-  };
-
-  const RESOLUTION_LABELS = {
-    best: 'Best Available',
-    '1080p': 'Up to 1080p',
-    '720p': 'Up to 720p',
-    '480p': 'Up to 480p'
   };
 
   const EXTRA_TYPE_LABELS = {
@@ -420,7 +412,6 @@ document.addEventListener('DOMContentLoaded', () => {
       title: elements.titleInput ? elements.titleInput.value.trim() : '',
       year: elements.yearInput ? elements.yearInput.value.trim() : '',
       tmdb: elements.tmdbInput ? elements.tmdbInput.value.trim() : '',
-      resolution: elements.resolutionSelect ? elements.resolutionSelect.value : 'best',
       extension: elements.extensionSelect ? elements.extensionSelect.value : 'mp4',
       extra: elements.extraCheckbox ? elements.extraCheckbox.checked : false,
       extraType: elements.extraTypeSelect ? elements.extraTypeSelect.value : 'trailer',

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,16 +104,6 @@
               <div class="advanced-group">
                 <h3>Download Preferences</h3>
                 <div class="form-group">
-                  <label for="resolution">Resolution Preference</label>
-                  <select id="resolution" name="resolution">
-                    <option value="best" selected>Best Available</option>
-                    <option value="1080p">Up to 1080p</option>
-                    <option value="720p">Up to 720p</option>
-                    <option value="480p">Up to 480p</option>
-                  </select>
-                </div>
-
-                <div class="form-group">
                   <label for="extension">File Extension</label>
                   <select id="extension" name="extension">
                     <option value="mp4" selected>MP4</option>


### PR DESCRIPTION
## Summary
- remove the resolution preference UI and request handling so downloads no longer send quality parameters
- simplify download metadata and yt-dlp invocation to rely on default best quality selection

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_6900d65b7be08329a47c81d418b78a39