### PR TITLE
Allow viewing logs from recent jobs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -469,6 +469,27 @@ button[type="submit"]:disabled {
   gap: 8px;
 }
 
+.download-item.is-interactive {
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.download-item.is-interactive:focus {
+  outline: none;
+}
+
+.download-item.is-interactive:focus-visible,
+.download-item.is-interactive:hover {
+  border-color: #2f81f7;
+  box-shadow: 0 0 0 1px rgba(47, 129, 247, 0.35);
+}
+
+.download-item.is-selected {
+  border-color: #2f81f7;
+  box-shadow: 0 0 0 1px rgba(47, 129, 247, 0.45);
+  background: #262b38;
+}
+
 .download-item .item-header {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- make download history cards clickable so users can reload logs for a recent job
- track the selected job to keep the console in sync with manual log viewing
- style recent job entries with hover and focus states to show they are interactive

## Testing
- python -m compileall app.py jobs.py

------
https://chatgpt.com/codex/tasks/task_e_6904b83f6a00832989d33043cafd0efd