### PR TITLE
Add toggle to hide debug console

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -15,7 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
     extraNameInput: document.getElementById('extra_name'),
     consoleDiv: document.getElementById('console'),
     downloadsList: document.getElementById('downloadsList'),
-    copyButton: document.getElementById('copyLogButton')
+    copyButton: document.getElementById('copyLogButton'),
+    toggleConsoleButton: document.getElementById('toggleConsoleButton'),
+    sideColumn: document.getElementById('debugConsoleRegion')
   };
 
   if (!elements.form) {
@@ -47,10 +49,38 @@ document.addEventListener('DOMContentLoaded', () => {
     ? document.body.dataset.debugMode === 'true'
     : false;
 
+  const CONSOLE_VISIBILITY_STORAGE_KEY = 'yt2radarr.consoleVisible';
+
+  function readConsoleVisibilityPreference(defaultValue = true) {
+    try {
+      const stored = window.localStorage.getItem(CONSOLE_VISIBILITY_STORAGE_KEY);
+      if (stored === 'true' || stored === 'false') {
+        return stored === 'true';
+      }
+    } catch (err) {
+      // Local storage may be unavailable (e.g., in private browsing mode)
+    }
+    return defaultValue;
+  }
+
+  function persistConsoleVisibility(value) {
+    try {
+      window.localStorage.setItem(
+        CONSOLE_VISIBILITY_STORAGE_KEY,
+        value ? 'true' : 'false'
+      );
+    } catch (err) {
+      // Ignore persistence errors
+    }
+  }
+
+  const initialConsoleVisible = readConsoleVisibilityPreference(true);
+
   const state = {
     downloads: [],
     pollers: new Map(),
     debugMode: initialDebugMode,
+    consoleVisible: initialConsoleVisible,
     lastLogs: [],
     copyFeedbackTimeout: null,
     selectedJobId: null,
@@ -95,6 +125,30 @@ document.addEventListener('DOMContentLoaded', () => {
       elements.copyButton.disabled = false;
     } else {
       elements.copyButton.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function setConsoleVisibility(enabled, options = {}) {
+    const { skipStorage = false } = options || {};
+    const value = Boolean(enabled);
+    state.consoleVisible = value;
+    if (document.body && document.body.dataset) {
+      document.body.dataset.consoleVisible = value ? 'true' : 'false';
+    }
+    if (elements.toggleConsoleButton) {
+      elements.toggleConsoleButton.textContent = value ? 'Hide Console' : 'Show Console';
+      elements.toggleConsoleButton.setAttribute('aria-expanded', value ? 'true' : 'false');
+      elements.toggleConsoleButton.setAttribute('aria-pressed', value ? 'true' : 'false');
+    }
+    if (elements.sideColumn) {
+      if (value) {
+        elements.sideColumn.removeAttribute('aria-hidden');
+      } else {
+        elements.sideColumn.setAttribute('aria-hidden', 'true');
+      }
+    }
+    if (!skipStorage) {
+      persistConsoleVisibility(value);
     }
   }
 
@@ -702,6 +756,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (elements.toggleConsoleButton) {
+    elements.toggleConsoleButton.addEventListener('click', () => {
+      setConsoleVisibility(!state.consoleVisible);
+    });
+  }
+
   elements.form.addEventListener('submit', async event => {
     event.preventDefault();
 
@@ -781,6 +841,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  setConsoleVisibility(initialConsoleVisible, { skipStorage: true });
   setDebugMode(initialDebugMode);
   updateExtraVisibility();
   renderDownloads();

--- a/static/style.css
+++ b/static/style.css
@@ -39,6 +39,28 @@ h1 {
   gap: 10px;
 }
 
+.header-actions .button-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.toggle-console-button {
+  gap: 6px;
+}
+
+.toggle-console-button[aria-expanded="false"] {
+  background: #2f81f7;
+  border-color: #2f81f7;
+  color: #fff;
+}
+
+.toggle-console-button[aria-expanded="false"]:hover {
+  background: #1f6feb;
+  border-color: #1f6feb;
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -424,10 +446,19 @@ button[type="submit"]:disabled {
     flex-wrap: wrap;
   }
 
+  .header-actions .button-secondary {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
   .header-actions .link-button {
     flex: 1 1 auto;
     justify-content: center;
   }
+}
+
+body[data-console-visible="false"] .side-column {
+  display: none;
 }
 
 .activity-panel {

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,10 @@
   />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
-<body data-debug-mode="{{ 'true' if debug_mode else 'false' }}">
+<body
+  data-debug-mode="{{ 'true' if debug_mode else 'false' }}"
+  data-console-visible="true"
+>
   <div class="app-shell">
     <div class="header">
       <div class="brand">
@@ -24,6 +27,15 @@
         <h1>YT2Radarr - Radarr YouTube Video Importer</h1>
       </div>
       <div class="header-actions">
+        <button
+          type="button"
+          id="toggleConsoleButton"
+          class="button-secondary toggle-console-button"
+          aria-controls="debugConsoleRegion"
+          aria-expanded="true"
+        >
+          Hide Console
+        </button>
         <a class="link-button" href="{{ url_for('setup') }}">Settings</a>
       </div>
     </div>
@@ -146,7 +158,7 @@
         </section>
       </div>
 
-      <aside class="side-column">
+      <aside class="side-column" id="debugConsoleRegion">
         <div class="console-header">
           <h2>Debug Console</h2>
           <button type="button" id="copyLogButton" class="copy-log-button" hidden>Copy Full Log</button>


### PR DESCRIPTION
## Summary
- add a header toggle that lets users hide or show the debug console
- persist console visibility preference and reflect it in the layout styling
- adjust frontend scripting to manage the toggle state alongside existing controls

## Testing
- Manual QA: toggled the debug console visibility in the web UI


------
https://chatgpt.com/codex/tasks/task_e_6904bbcc57b48329b26930aa530c4c2f