### PR TITLE
fix(docker): respect runtime UID/GID and disable gunicorn control socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
+    gosu \
     curl \
     unzip \
     ca-certificates \
@@ -29,7 +30,6 @@ RUN mkdir -p /config
 
 # Create the runtime user
 RUN useradd -m appuser && chown -R appuser /app /config
-USER appuser
 
 ENV FLASK_APP=app.py
 ENV FLASK_ENV=production
@@ -37,4 +37,8 @@ ENV YT2RADARR_CONFIG_DIR=/config
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["gunicorn", "--no-control-socket", "--bind", "0.0.0.0:5000", "app:app"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+APP_USER="appuser"
+
+mkdir -p /config
+
+# If running as root → support PUID/PGID
+if [ "$(id -u)" = "0" ]; then
+  if [ -n "${PGID:-}" ]; then
+    groupmod -o -g "$PGID" "$APP_USER" 2>/dev/null || true
+  fi
+
+  if [ -n "${PUID:-}" ]; then
+    usermod -o -u "$PUID" "$APP_USER" 2>/dev/null || true
+  fi
+
+  chown -R "$APP_USER":"$APP_USER" /config /app 2>/dev/null || true
+
+  exec gosu "$APP_USER" "$@"
+fi
+
+# If user used docker -u → respect it
+exec "$@"


### PR DESCRIPTION
## What does this PR do?
Fixes user passing and gunicorn control socker error

## How did you test it?
Verified:
- default container startup still works
- running with `-u $(id -u):$(id -g)` works
- running with `PUID` / `PGID` works
- config files created in mounted `/config` are owned by the expected host user

## In order to be reviewed quickly, please provide a funny pun about fish
What do you call a fish with no eyes? A fsh.